### PR TITLE
Upgrade pytest dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,15 @@ jobs:
   build:
     docker:
       # https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/python:3.8.1-buster-browsers
+      - image: circleci/python:3.8.3-buster-browsers
     working_directory: ~/repo
     steps:
       - checkout
 
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "setup.py" }}
-            - v3-dependencies-
+            - v4-dependencies-{{ checksum "setup.py" }}
+            - v4-dependencies-
 
       - run:
           name: install dependencies
@@ -25,7 +25,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v3-dependencies-{{ checksum "setup.py" }}
+          key: v4-dependencies-{{ checksum "setup.py" }}
 
       - run:
           name: run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python_version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Store pip cache
         uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,13 +15,13 @@ jobs:
         run: |
           sudo apt -y update
           sudo apt install -y chromium-chromedriver
-      - uses: actions/checkout@v1.1.0
-      - uses: actions/setup-python@v1.1.1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
         with:
           python_version: ${{ matrix.python-version }}
           architecture: x64
       - name: Store pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.OS }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
@@ -39,12 +39,12 @@ jobs:
           pytest --cov=htexpr --cov-report=html --junitxml=results/pytest/junit.xml tests
           pytest --headless examples
       - name: Upload test report
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v2
         with:
           name: test-report
           path: results
       - name: Upload code coverage
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v2
         with:
           name: coverage-report
           path: htmlcov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ exclude = '''
 
 [build-system]
 requires = ["setuptools", "wheel"]
+
+[tool.pytest.ini_options]
+junit_family = "xunit2"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ example_requirements = [
 test_requirements = [
     "pytest~=5.4.3",
     "pytest-cov>=2.8.1,<2.11.0",
+    "pytest-sugar~=0.9.3",
     "dash-core-components>=0.44,<1.11",
     "dash[testing]>=1.0.0,<1.14",
     "dash-html-components>=0.14,<1.1",

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,8 @@ example_requirements = [
     "dash-bootstrap-components>=0.7.2,<0.11",
 ]
 test_requirements = [
-    "pytest~=5.3.0",
+    "pytest~=5.4.3",
     "pytest-cov>=2.8.1,<2.11.0",
-    # workaround for newer pytest:
-    # "pytest-sugar @ git+https://github.com/GuillaumeFavelier/pytest-sugar.git@b56fed42d5c3022ff507ab6ce81cda65a3a5f92a#egg=pytest-sugar",
     "dash-core-components>=0.44,<1.11",
     "dash[testing]>=1.0.0,<1.14",
     "dash-html-components>=0.14,<1.1",


### PR DESCRIPTION
I think the pytest-sugar bug is fixed.

Also upgrade CI runner configurations and get rid of a deprecation warning.

Once pytest 6 is released, we can use pyproject.toml for its configuration, but for now it needs its own file.